### PR TITLE
Converting plain-text formulae to latex math

### DIFF
--- a/jdftx/doc/Doxyfile.in
+++ b/jdftx/doc/Doxyfile.in
@@ -1407,7 +1407,7 @@ FORMULA_TRANSPARENT    = YES
 # The default value is: NO.
 # This tag requires that the tag GENERATE_HTML is set to YES.
 
-USE_MATHJAX            = NO
+USE_MATHJAX            = YES
 
 # When MathJax is enabled you can set the default output format to be used for
 # the MathJax output. See the MathJax site (see:

--- a/jdftx/doc/tutorials/molecule/SolvationIon.dox
+++ b/jdftx/doc/tutorials/molecule/SolvationIon.dox
@@ -164,11 +164,11 @@ and vibration calculations are usually necessary for reliable free energies.
 
 The reaction free energy, DeltaA, calculated above sets the equilibrium:
 
-exp(-DeltaA/kT) = [H3O+][OH-]/[H2O]<sup>2</sup>
+\f$ exp(\frac{-\triangle A}{kT}) = \frac{[H3O+][OH-]}{[H2O]^2} \f$
 
 Using its definition, the dissociation constant of water is therefore:
 
-pKw = -log<sub>10</sub>([H3O+][OH-]) = DeltaA/(2.303 kT) - 2 log<sub>10</sub>[H2O]
+\f$ pK_w = -log_{10}([H3O+][OH-]) = \frac{\triangle A}{2.303 kT} - 2 log_{10}[H2O] \f$
 
 With kT = 0.000944 Hartrees and [H2O] = 55.5M at standard temperature and pressure,
 CANDLE therefore predicts pKw = 17.5 in good agreement

--- a/jdftx/doc/tutorials/solid/BandStructure.dox
+++ b/jdftx/doc/tutorials/solid/BandStructure.dox
@@ -37,7 +37,7 @@ which we run with
 
     mpirun -n 4 jdftx -i totalE.in | tee totalE.out
 
-Note the new command \ref CommandElectronicSCF, which uses a different algorithm
+Note the new command \ref CommandElectronicScf, which uses a different algorithm
 from the variational minimize to solve the Kohn-Sham equations.
 Essentially, Kohn-Sham eigenvalues and orbitals are calculated for an input potential,
 and a new density and potential are constructed from those orbitals.


### PR DESCRIPTION
also includes a hyperlink fix for ElectronicSCF