### PR TITLE
Update Dockerfile for Ubuntu 24.04

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,14 @@
-FROM ubuntu:16.04
+FROM ubuntu:24.04
+
 RUN apt-get -y update && apt-get -y --no-install-recommends install g++ cmake libgsl0-dev libopenmpi-dev openmpi-bin libfftw3-dev libatlas-base-dev liblapack-dev wget unzip ca-certificates make && \
 	cd /root && \
 	wget https://github.com/shankar1729/jdftx/archive/refs/heads/master.zip && unzip master.zip && rm master.zip && \
 	cd jdftx-master && mkdir build && cd build && \
 	cmake ../jdftx && make all && make install && \
         make test && \
-        apt-get -y purge gcc g++ cmake cmake-data g++-5 gfortran-5 make libarchive13 libcurl3 libgfortran-5-dev libjsoncpp1 liblzo2-2 libstdc++-5-dev wget unzip ca-certificates && rm -rf /var/lib/apt/lists/* && \
         cd /root && rm -rf /root/jdftx-master && \
         echo 'export PATH="$PATH:/usr/local/share/jdftx/scripts"' >> /root/.bashrc && mkdir /root/research
+
 WORKDIR /root/research
 
 #Use it like this:

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,7 @@ RUN apt-get -y update && apt-get -y --no-install-recommends install g++ cmake li
 	cd jdftx-master && mkdir build && cd build && \
 	cmake ../jdftx && make all && make install && \
         make test && \
+	apt-get -y purge g++ cmake wget unzip ca-certificates make && \
         cd /root && rm -rf /root/jdftx-master && \
         echo 'export PATH="$PATH:/usr/local/share/jdftx/scripts"' >> /root/.bashrc && mkdir /root/research
 


### PR DESCRIPTION
Hi @shankar1729, just a quick PR.

The Dockerfile in the repo no longer compiled for me and I noticed it was running an older version of Ubuntu.

This change updates to Ubuntu 24.04 LTS (Long Term Support, this version supported until June 2029 so hopefully a good version to use). I had to remove the `apt-get -y purge` line also since several of the packages trying to be removed are no longer installed, so this line would error out. I can confirm that all tests pass.