### PR TITLE
Origin parameter for ionic-gaussian-potential

### DIFF
--- a/jdftx/commands/ionic_dynamics.cpp
+++ b/jdftx/commands/ionic_dynamics.cpp
@@ -256,6 +256,15 @@ struct CommandIonicGaussianPotential : public Command
 		pl.get(igp.U0, 0.0, "U0", true);
 		pl.get(igp.sigma, 0.0, "sigma", true);
 		pl.get(igp.geometry, IonicGaussianPotential::Planar, igpGeometryMap, "geometry", true);
+		vector3<> origin(0.0, 0.0, 0.0);
+		string key;
+		pl.get(key, string(), "origin", false);
+		if(key == "origin")
+		{	pl.get(origin[0], 0.0, "x", true);
+			pl.get(origin[1], 0.0, "y", true);
+			pl.get(origin[2], 0.0, "z", true);
+		}
+		igp.origin = origin;
 		e.iInfo.ionicGaussianPotentials.push_back(igp);
 	}
 

--- a/jdftx/commands/ionic_dynamics.cpp
+++ b/jdftx/commands/ionic_dynamics.cpp
@@ -283,8 +283,8 @@ struct CommandIonicGaussianPotential : public Command
 
 	void printStatus(Everything& e, int iRep)
 	{	const IonicGaussianPotential& igp = e.iInfo.ionicGaussianPotentials[iRep];
-		logPrintf("%s %lg %lg %s", e.iInfo.species[igp.iSpecies]->name.c_str(),
-			igp.U0, igp.sigma, igpGeometryMap.getString(igp.geometry));
+		logPrintf("%s %lg %lg %s origin %19.15lf %19.15lf %19.15lf", e.iInfo.species[igp.iSpecies]->name.c_str(),
+			igp.U0, igp.sigma, igpGeometryMap.getString(igp.geometry), igp.origin[0], igp.origin[1], igp.origin[2]);
 	}
 }
 commandIonicGaussianPotential;

--- a/jdftx/electronic/IonicGaussianPotential.cpp
+++ b/jdftx/electronic/IonicGaussianPotential.cpp
@@ -8,7 +8,7 @@ double IonicGaussianPotential::energyAndGrad(const GridInfo& gInfo, std::vector<
 		if(atom.sp == iSpecies)
 		{
 			//Compute wrapped Cartesian position:
-			vector3<> posWrapped = atom.pos;
+			vector3<> posWrapped = atom.pos - origin; //shift to origin of Gaussian
 			for(int iDir=0; iDir<3; iDir++)
 				posWrapped[iDir] -= floor(0.5 + posWrapped[iDir]); //to [-0.5, 0.5)
 			vector3<> r = gInfo.R * posWrapped;

--- a/jdftx/electronic/IonicGaussianPotential.h
+++ b/jdftx/electronic/IonicGaussianPotential.h
@@ -30,8 +30,9 @@ struct IonicGaussianPotential
 	double U0; //!< peak amplitude in Hartrees
 	double sigma; //!< width (standard deviation) in bohrs
 	enum Geometry {Spherical, Cylindrical, Planar} geometry;
-	
-	IonicGaussianPotential() : iSpecies(-1), U0(0.), sigma(0.), geometry(Spherical) {}
+	vector3<> origin; //!< origin of the Gaussian potential in reduced coordinates (0.5,0.5,0.5) is center of cell
+
+	IonicGaussianPotential() : iSpecies(-1), U0(0.), sigma(0.), geometry(Spherical), origin(0.0, 0.0, 0.0) {}
 	
 	//Compute energy and accumulate forces, and optionally stresses, due to external potential:
 	double energyAndGrad(const GridInfo& gInfo, std::vector<Atom>& atoms, matrix3<>* E_RRTptr) const;


### PR DESCRIPTION
- Adds an optional "origin" parameter to "ionic-gaussian-potential" tag
-- Specifies center of added ionic-gaussian-potential in lattice coordinates
-- Defaults to cell origin (previous behavior)

Testing
- Built on perlmutter with 'run-cmake-gpu.sh' script
- Tested on a sample AIMD calculation
-- Performs identically to pre-existing version when origin not specified
-- Gives different "forceExtIonic" forces when origin specified to something not (0.0, 0.0, 0.0)